### PR TITLE
Check for cloudmesh rc files

### DIFF
--- a/bin/openstack-setup-test
+++ b/bin/openstack-setup-test
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+RC_FILES=(
+    ~/.cloudmesh/clouds/india/havana
+    ~/.cloudmesh/clouds/india/juno
+)
+
+print-help() {
+    echo "Usage: $0 [-h] -c"
+    echo "  -c    Run check"
+    echo "  -h    Print this help"
+    echo
+    echo "This script tests for the presence of cloudmesh RC files:"
+    for p in ${RC_FILES[@]}; do
+	echo "    $p"
+    done
+}
+
+usage() {
+    print-help
+    exit 1
+}
+
+
+print-failure-msg() {
+    echo "ERROR Cloud not find the needed cloudmesh files."
+    echo "Please send an email to help@futuresystems.org"
+}
+
+
+test-file() {
+    local path="$1"
+    echo -n "Checking for $path..."
+    if test -f $path; then
+	echo "OK"
+	return 0
+    else
+	echo "FAIL"
+	return 2
+    fi
+}
+
+
+main() {
+    fail=1
+    for path in ${RC_FILES[@]}; do
+	if ! test-file "$path"; then
+	    fail=0
+	fi
+    done
+    if [ fail ]; then
+	print-failure-msg
+	exit 2
+    fi
+    exit 0
+}
+
+test -z "$@" && usage
+
+while getopts ":hc" arg; do
+    case $arg in
+	c)
+	    main
+	    ;;
+	*)
+	    usage
+	    ;;
+    esac
+done

--- a/bin/openstack-setup-test
+++ b/bin/openstack-setup-test
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 RC_FILES=(
-    ~/.cloudmesh/clouds/india/havana
-    ~/.cloudmesh/clouds/india/juno
+    ~/.cloudmesh/clouds/india/havana/novarc
+    ~/.cloudmesh/clouds/india/juno/openrc.sh
 )
 
 print-help() {

--- a/bin/openstack-setup-test
+++ b/bin/openstack-setup-test
@@ -31,7 +31,7 @@ print-failure-msg() {
 test-file() {
     local path="$1"
     echo -n "Checking for $path..."
-    if test -f $path; then
+    if test -e $path; then
 	echo "OK"
 	return 0
     else


### PR DESCRIPTION
Check for the presence of cloudmesh rc files under ~/.cloudmesh.

In particular:
 - `~/.cloudmesh/clouds/india/havana`
 - `~/.cloudmesh/clouds/india/juno`

Example output on my system:
```
$ ./bin/openstack-setup-test  -h
Usage: ./bin/openstack-setup-test [-h] -c
  -c    Run check
  -h    Print this help

This script tests for the presence of cloudmesh RC files:
    /home/badi/.cloudmesh/clouds/india/havana
    /home/badi/.cloudmesh/clouds/india/juno

$ ./bin/openstack-setup-test  -c
Checking for /home/badi/.cloudmesh/clouds/india/havana...FAIL
Checking for /home/badi/.cloudmesh/clouds/india/juno...FAIL
ERROR Cloud not find the needed cloudmesh files.
Please send an email to help@futuresystems.org
```

@laszewsk Is this what you had in mind?
CC @lee212 