### PR TITLE
Cleanup checks for OS X major (10.YX) versions

### DIFF
--- a/cloudmesh_install/util.py
+++ b/cloudmesh_install/util.py
@@ -45,10 +45,13 @@ def is_osx():
     osx = platform.system().lower() == 'darwin'
     if osx:
         os_version = platform.mac_ver()[0]
-        if os_version not in ['10.9.5', '10.10']:
-            osx = False
-            print("WARNING: %s %s is not tested" % ('OSX', os_version))
-    return osx
+        for supported_version in ['10.9', '10.10']:
+            if os_version.startswith(supported_version):
+                return True
+        print("WARNING: %s %s is not tested" % ('OSX', os_version))
+        return False
+    else:
+        return False
 
 
 def banner(txt=None, c="#", debug=True):


### PR DESCRIPTION
Previous code checked for hardcoded versions (eg 10.9.5, 10.10).  A
system running 10.10.2 would fail this check.  It seems reasonable to
assume that what works on 10.10.1 should be fine on 10.10.2. This
change checks that the os version (eg 10.10.X) starts with a supported
version (et 10.10).